### PR TITLE
add game-over and highscore screens

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -14,9 +14,15 @@
         font-weight: 500;
         font-style: normal;
       }
+      .font-trigger {
+        position: absolute;
+        font-family: "FORCED SQUARE";
+        opacity: 0;
+      }
     </style>
   </head>
   <body>
+    <div class="font-trigger">.</div>
     <script src="./index.js"></script>
   </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,20 @@
 import { Game } from "phaser";
-import { HudScene } from "./scenes/hud";
-import { InstructionsScene } from "./scenes/instructions";
-import { hud, instructions, menu, play } from "./scenes/keys";
-import { MenuScene } from "./scenes/menu";
-import { PlayScene } from "./scenes/play";
+import {
+  GameOverScene,
+  HighscoresScene,
+  HudScene,
+  InstructionsScene,
+  MenuScene,
+  PlayScene
+} from "./scenes";
+import {
+  game_over,
+  highscores,
+  hud,
+  instructions,
+  menu,
+  play
+} from "./scenes/keys";
 import { createCoordinates } from "./utils/coordinates";
 
 const width = document.body.clientWidth;
@@ -31,3 +42,5 @@ game.scene.add(menu, MenuScene);
 game.scene.add(play, PlayScene);
 game.scene.add(hud, HudScene);
 game.scene.add(instructions, InstructionsScene);
+game.scene.add(game_over, GameOverScene);
+game.scene.add(highscores, HighscoresScene);

--- a/src/scenes/gameover/index.js
+++ b/src/scenes/gameover/index.js
@@ -1,0 +1,117 @@
+// Scene for HUD while playing (will listen to events from playscene for showing score, upcoming block, level)...
+import { Scene } from "phaser";
+import { getCoordinates } from "../../utils/coordinates";
+import { addText } from "../../utils/text";
+import { highscores, menu } from "../keys";
+
+const ALLOWED_CHARS = "0123456789abcdefghijklmnopqrstuvwxyz ?!._";
+
+export class GameOverScene extends Scene {
+  constructor(config) {
+    super(config);
+    this.dimensions = getCoordinates();
+  }
+
+  create({ score }) {
+    this.name = "";
+    this.score = score;
+    this.highScores = JSON.parse(localStorage.getItem("highscores")) || [];
+
+    if (
+      this.highScores.length < 5 ||
+      this.highScores.some(highScore => score > highScore.score)
+    ) {
+      this.addHighScore();
+    } else {
+      this.gameOverNotification = addText(
+        this,
+        this.dimensions.center.x - 200,
+        this.dimensions.center.y - 300,
+        [
+          { text: "GAME OVER", style: "title" },
+          { text: `SCORE: ${score}`, style: "heading" },
+          { text: `Press <ENTER> to return to the menu.`, style: "text" }
+        ]
+      );
+      this.input.keyboard.on("keydown", event => {
+        if (event.key === "Enter") {
+          this.scene.start(menu);
+        }
+      });
+    }
+  }
+  addHighScore() {
+    this.events.on("shutdown", () => {
+      this.timer && clearTimeout(this.timer);
+    });
+    this.cursor = this.add.rectangle(
+      this.dimensions.center.x - 200,
+      this.dimensions.center.y - 68,
+      12,
+      20,
+      0xf9f9f9,
+      1
+    );
+    this.toggleCursor();
+    this.userInput = addText(
+      this,
+      this.dimensions.center.x - 200,
+      this.dimensions.center.y - 100,
+      [{ text: this.name, style: "label" }]
+    );
+    this.scoreValue = addText(
+      this,
+      this.dimensions.center.x + 200,
+      this.dimensions.center.y - 100,
+      [{ text: this.score, style: "value" }]
+    );
+    this.gameOverNotification = addText(
+      this,
+      this.dimensions.center.x - 200,
+      this.dimensions.center.y - 300,
+      [
+        { text: "GAME OVER", style: "title" },
+        {
+          text: `Congratulations, a new highscore! Such wow! Enter your name and press <ENTER> to submit your highscore to the list.`,
+          style: "text",
+          centered: false
+        }
+      ]
+    );
+
+    this.input.keyboard.on("keydown", event => {
+      if (ALLOWED_CHARS.includes(event.key.toLowerCase())) {
+        this.name = (this.name += event.key).slice(0, 24);
+        this.userInput[0].setText(this.name);
+        this.cursor.setX(
+          this.dimensions.center.x - 200 + this.userInput[0].width + 5
+        );
+      } else if (event.key === "Backspace") {
+        this.name = this.name.substring(0, this.name.length - 1);
+        this.userInput[0].setText(this.name);
+        this.cursor.setX(
+          this.dimensions.center.x - 200 + this.userInput[0].width + 5
+        );
+      } else if (event.key === "Enter") {
+        this.onSave();
+      }
+    });
+  }
+
+  toggleCursor() {
+    let alpha = this.cursor.alpha ? 0 : 1;
+    this.cursor.setAlpha(alpha);
+
+    this.timer = setTimeout(this.toggleCursor.bind(this), 500);
+  }
+
+  onSave() {
+    this.highScores.push({ score: this.score, name: this.name });
+    this.highScores.sort((a, b) => b.score - a.score);
+    localStorage.setItem(
+      "highscores",
+      JSON.stringify(this.highScores.slice(0, 5))
+    );
+    this.scene.start(highscores);
+  }
+}

--- a/src/scenes/highscores/index.js
+++ b/src/scenes/highscores/index.js
@@ -1,0 +1,59 @@
+// Scene for HUD while playing (will listen to events from playscene for showing score, upcoming block, level)...
+import { Scene } from "phaser";
+import { getCoordinates } from "../../utils/coordinates";
+import { addText } from "../../utils/text";
+import { menu } from "../keys";
+
+export class HighscoresScene extends Scene {
+  constructor(config) {
+    super(config);
+    this.dimensions = getCoordinates();
+  }
+
+  create() {
+    this.enter = this.input.keyboard.addKey("ENTER");
+    this.enter.on("down", this.onEnter.bind(this));
+    this.highScores = JSON.parse(localStorage.getItem("highscores")) || [];
+
+    this.header = addText(
+      this,
+      this.dimensions.center.x - 200,
+      this.dimensions.center.y - 300,
+      [{ text: "HIGHSCORES", style: "title" }]
+    );
+    this.highScoreNames = addText(
+      this,
+      this.dimensions.center.x - 200,
+      this.dimensions.center.y - 200,
+      this.highScores.map(({ name }) => ({
+        text: name,
+        style: "label"
+      }))
+    );
+
+    this.highScoreValues = addText(
+      this,
+      this.dimensions.center.x + 200,
+      this.dimensions.center.y - 200,
+      this.highScores.map(({ score }) => ({
+        text: score,
+        style: "value"
+      }))
+    );
+
+    this.outro = addText(
+      this,
+      this.dimensions.center.x - 200,
+      this.dimensions.center.y + 200,
+      [
+        {
+          text: "Press <ENTER> to return to menu"
+        }
+      ]
+    );
+  }
+
+  onEnter() {
+    this.scene.start(menu);
+  }
+}

--- a/src/scenes/index.js
+++ b/src/scenes/index.js
@@ -1,0 +1,6 @@
+export { GameOverScene } from "./gameover";
+export { HighscoresScene } from "./highscores";
+export { HudScene } from "./hud";
+export { InstructionsScene } from "./instructions";
+export { MenuScene } from "./menu";
+export { PlayScene } from "./play";

--- a/src/scenes/instructions/index.js
+++ b/src/scenes/instructions/index.js
@@ -1,6 +1,6 @@
 import { Scene } from "phaser";
 import { getCoordinates } from "../../utils/coordinates";
-import { addMultilineText } from "../../utils/text";
+import { addText } from "../../utils/text";
 import { menu } from "../keys";
 
 export class InstructionsScene extends Scene {
@@ -16,38 +16,67 @@ export class InstructionsScene extends Scene {
       this.enter.on("down", this.onEnter.bind(this));
     }
 
-    this.instructions = addMultilineText(
+    this.header = addText(
       this,
       this.dimensions.center.x - 200,
       this.dimensions.center.y - 300,
+      [{ text: "INSTRUCTIONS", style: "title" }]
+    );
+    this.controlsHeader = addText(
+      this,
+      this.dimensions.center.x - 200,
+      this.dimensions.center.y - 220,
+      [{ text: "CONTROLS", style: "heading" }]
+    );
+
+    this.controls = addText(
+      this,
+      this.dimensions.center.x - 200,
+      this.dimensions.center.y - 160,
+      [{ text: "<LEFT>\n<RIGHT>\n<DOWN>\n<UP>\n<SPACE>" }]
+    );
+    this.controlsExplanation = addText(
+      this,
+      this.dimensions.center.x - 100,
+      this.dimensions.center.y - 160,
       [
-        { text: "INSTRUCTIONS", type: "title" },
-        { text: "CONTROLS", type: "heading" },
         {
           text:
-            "Use <LEFT>, <RIGHT> and <DOWN> arrow keys to move the block. Use <UP> arrow key to rotate. Use <SPACE> to directly drop the current block to the floor.",
-          type: "text"
-        },
-        { text: "SCORE", type: "heading" },
-        {
-          text:
-            "For a single row you get 1 point. If you complete 2 rows with one block, you get 3 points. For 3 rows you get 6 points, and 4 rows yields 10 points.",
-          type: "text"
-        },
-        { text: "LEVEL", type: "heading" },
-        {
-          text:
-            "After a certain amount of points you will advance a level. This means that the blocks will drop a bit faster by themselves.",
-          type: "text"
-        },
-        {
-          text: "Press <ENTER> to return to the menu.",
-          type: "text"
+            "move current block to the left\nmove current block to the right\nmove current block down\nrotate current block\ndirectly drop the current block to the floor"
         }
       ]
     );
-    // this.dimensions.center.x,
-    // this.dimensions.center.y + BASE_OFFSET + index * (FONT.size + 10),
+    this.scoreHeader = addText(
+      this,
+      this.dimensions.center.x - 200,
+      this.dimensions.center.y,
+      [
+        { text: "SCORE", style: "heading" },
+        {
+          text:
+            "For each completed row you get points. If you complete multiple rows with a single block, you can generate bonus points."
+        }
+      ]
+    );
+    this.scoring = addText(
+      this,
+      this.dimensions.center.x - 200,
+      this.dimensions.center.y + 160,
+      [{ text: "ONE ROW\nTWO ROWS\nTHREE ROWS\nFOUR ROWS\n" }]
+    );
+    this.scoringExplanation = addText(
+      this,
+      this.dimensions.center.x - 60,
+      this.dimensions.center.y + 160,
+      [{ text: "1 point\n3 points\n6 points\n10 points\n" }]
+    );
+
+    this.outro = addText(
+      this,
+      this.dimensions.center.x - 200,
+      this.dimensions.center.y + 300,
+      [{ text: "Press <ENTER> to return to the menu" }]
+    );
   }
 
   update() {}

--- a/src/scenes/keys.js
+++ b/src/scenes/keys.js
@@ -2,3 +2,5 @@ export const play = "play";
 export const hud = "hud";
 export const menu = "menu";
 export const instructions = "instructions";
+export const game_over = "game_over";
+export const highscores = "highscores";

--- a/src/scenes/menu/index.js
+++ b/src/scenes/menu/index.js
@@ -1,13 +1,13 @@
 import { Scene } from "phaser";
 import { getCoordinates } from "../../utils/coordinates";
-import { addMenuItem, FONT } from "../../utils/text";
-import { hud, instructions, play } from "../keys";
+import { addText } from "../../utils/text";
+import { highscores, hud, instructions, play } from "../keys";
 
 const MENU_ITEMS = [
-  { text: "NEW GAME", scenes: [hud, play] },
-  { text: "INSTRUCTIONS", scenes: [instructions] }
+  { text: "NEW GAME", style: "heading", scenes: [hud, play] },
+  { text: "HIGHSCORES", style: "heading", scenes: [highscores] },
+  { text: "INSTRUCTIONS", style: "heading", scenes: [instructions] }
 ];
-const BASE_OFFSET = -((MENU_ITEMS.length * (FONT.size + 10)) / 2);
 
 export class MenuScene extends Scene {
   constructor(config) {
@@ -26,34 +26,42 @@ export class MenuScene extends Scene {
       this.cursors.down.on("down", this.onDown.bind(this));
     }
 
-    this.menuItems = MENU_ITEMS.map(({ text }, index) => {
-      return addMenuItem(
-        this,
-        this.dimensions.center.x,
-        this.dimensions.center.y + BASE_OFFSET + index * (FONT.size + 10),
-        text
-      );
-    });
+    this.menuHeader = addText(
+      this,
+      this.dimensions.center.x - 200,
+      this.dimensions.center.y - 300,
+      [{ text: "TETRIS", style: "title" }]
+    );
+    this.menuItems = addText(
+      this,
+      this.dimensions.center.x - 200,
+      this.dimensions.center.y - 200,
+      MENU_ITEMS
+    );
+    this.highlightSelection();
   }
 
-  update() {
-    this.menuItems.forEach((item, index) => {
-      let color = index === this.selectedItem ? "#f9f9f9" : "#909090";
-      item.setColor(color);
-    });
-  }
+  update() {}
 
   onUp() {
     this.selectedItem =
       this.selectedItem === 0 ? MENU_ITEMS.length - 1 : this.selectedItem - 1;
+    this.highlightSelection();
   }
   onDown() {
     this.selectedItem =
       this.selectedItem === MENU_ITEMS.length - 1 ? 0 : this.selectedItem + 1;
+    this.highlightSelection();
   }
   onSelect() {
     MENU_ITEMS[this.selectedItem].scenes.forEach(scene => {
       this.scene.start(scene);
+    });
+  }
+  highlightSelection() {
+    this.menuItems.forEach((item, index) => {
+      let color = index === this.selectedItem ? "#f9f9f9" : "#909090";
+      item.setColor(color);
     });
   }
 }

--- a/src/scenes/play/index.js
+++ b/src/scenes/play/index.js
@@ -3,7 +3,7 @@ import { createStore } from "redux";
 import { install } from "redux-loop";
 import { getCoordinates } from "../../utils/coordinates";
 import { grid } from "../../utils/grid";
-import { hud, menu } from "../keys";
+import { game_over, hud } from "../keys";
 import { tetris } from "./tetris.js";
 
 export class PlayScene extends Scene {
@@ -80,7 +80,7 @@ export class PlayScene extends Scene {
       clearTimeout(this.ticker);
       this.unsubscribeStore();
       this.scene.stop(hud);
-      this.scene.start(menu);
+      this.scene.start(game_over, { score: state.score });
       return;
     }
 

--- a/src/utils/text.js
+++ b/src/utils/text.js
@@ -1,47 +1,69 @@
 export const fonts = {
-  title: 50,
-  heading: 30,
-  text: 20
+  title: {
+    size: 50,
+    margin: 30,
+    origin: 0.5
+  },
+  heading: {
+    size: 30,
+    margin: 20,
+    origin: 0.5
+  },
+  label: {
+    size: 30,
+    margin: 20,
+    origin: 0
+  },
+  value: {
+    size: 30,
+    margin: 20,
+    origin: 1
+  },
+  text: {
+    size: 20,
+    margin: 10,
+    origin: 0
+  },
+  none: {
+    margin: 0,
+    size: 0,
+    origin: 0
+  }
 };
 
-export const FONT = {
-  size: 30
-};
-
-function getFontStyle(size) {
+function getFont(size) {
   return {
     fontFamily: '"FORCED SQUARE", sans-serif',
     fontSize: size + "px"
   };
 }
 
-const regular = {
-  fontFamily: '""'
-};
+export const addText = (scene, x, y, textArr, wrap = 400) => {
+  let returnArr = [];
 
-export const addMenuItem = (scene, x, y, text) => {
-  let item = scene.add.text(x, y, text, getFontStyle(fonts.heading));
+  textArr.reduce(
+    (acc, { text, style = "text", color = "#f9f9f9" }) => {
+      let newY = acc.y + Math.max(fonts[acc.style].margin, fonts[style].margin);
+      let item = scene.add.text(x, newY, text, getFont(fonts[style].size));
+      item.setColor(color);
+      item.setLineSpacing(fonts[style].size / 2);
 
-  item.setOrigin(0.5, 0.5);
-  item.setColor("#f9f9f9");
-  return item;
+      item.setOrigin(fonts[style].origin, 0);
+      fonts[style].origin === 0.5 && item.setX(x + wrap / 2);
+      item.setWordWrapWidth(wrap, true);
+
+      returnArr.push(item);
+
+      return { style, y: newY + item.height };
+    },
+    { style: "none", y }
+  );
+  return returnArr;
 };
 
 export const addHudItem = (scene, x, y, text) => {
-  let item = scene.add.text(x, y, text, getFontStyle(fonts.heading));
+  let item = scene.add.text(x, y, text, getFont(fonts.heading.size));
   item.setOrigin(1, 0);
   item.setColor("#f9f9f9");
   return item;
-};
-
-export const addMultilineText = (scene, x, y, textArr) => {
-  let returnArr = [];
-  textArr.reduce((acc, { text, type }) => {
-    let line = scene.add.text(x, y + acc, text, getFontStyle(fonts[type]));
-
-    line.setWordWrapWidth(400, true);
-    returnArr.push(line);
-    return acc + line.height + 20;
-  }, 0);
-  return returnArr;
 };


### PR DESCRIPTION
Resolves #8 and Resolves #3 
Add screens for Game Over state and Highscores (new in the menu). With these changes also some refactoring on adding texts, its not great yet but it helped develop some text stuff a bit faster.

The game-over state checks if a new highscore has been reached. If so, it asks the user for a name, and it will store it with LocalStorage. The highscores are then shown, but are also available through the menu.